### PR TITLE
Update public key to be string directly given

### DIFF
--- a/aks_cluster/cluster.tf
+++ b/aks_cluster/cluster.tf
@@ -35,7 +35,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
     admin_username = var.admin_username
 
     ssh_key {
-      key_data = file(var.public_ssh_key_path)
+      key_data = var.public_ssh_key
     }
   }
 

--- a/aks_cluster/variables.tf
+++ b/aks_cluster/variables.tf
@@ -155,9 +155,9 @@ variable "pod_cidr" {
   default     = null
 }
 
-variable "public_ssh_key_path" {
+variable "public_ssh_key" {
   type        = string
-  description = "The path to the ssh pub file, tied to the admin user in linux_profile"
+  description = "Public SSH key tied to the admin user in linux_profile"
 }
 
 variable "region" {


### PR DESCRIPTION
Instead of looking for a filepath, we should provide the pub key as a string directly so that this can run more easily in terraform cloud environments. 