### PR TITLE
standardize on https style pull

### DIFF
--- a/virtual_network/main.tf
+++ b/virtual_network/main.tf
@@ -9,7 +9,7 @@ locals {
 }
 
 module "subnet_addrs" {
-  source          = "git@github.com:hashicorp/terraform-cidr-subnets.git?ref=v1.0.0"
+  source          = "github.com/hashicorp/terraform-cidr-subnets.git?ref=v1.0.0"
   base_cidr_block = local.network_cidr
   networks        = local.network_objs
 }


### PR DESCRIPTION
- We are inconsistently using pull styles, standardizing on `https` for better compatibility with TF Cloud, see https://www.terraform.io/docs/language/modules/sources.html#github