### PR TITLE
name to display_name

### DIFF
--- a/aks_cluster/aad.tf
+++ b/aks_cluster/aad.tf
@@ -1,9 +1,7 @@
 # Create Service Principal for AKS cluster
 resource "azuread_application" "aks_sp_application" {
   count                      = local.use_aks_sp ? 1 : 0
-  name                       = "${var.cluster_name}-aks"
-  available_to_other_tenants = false
-  oauth2_allow_implicit_flow = false
+  display_name               = "${var.cluster_name}-aks"
 }
 
 resource "azuread_service_principal" "aks_sp" {
@@ -35,5 +33,5 @@ resource "azurerm_role_assignment" "aks_sp_role_assignment" {
 # Create a cluster admin group
 resource "azuread_group" "aks-aad-clusteradmins" {
   count = var.enable_aad_auth ? 1 : 0
-  name  = "${var.cluster_name}-clusteradmin"
+  display_name  = "${var.cluster_name}-clusteradmin"
 }


### PR DESCRIPTION
- name is depreciated, replacing with `display_name`
- `available_to_other_tenants = false` is the default, and not expected here. removing
- `oauth2_allow_implicit_flow = false` is the default, and not expected here. removing