### PR TITLE
fixup security enabled, dynamic gen

### DIFF
--- a/aks_cluster/aad.tf
+++ b/aks_cluster/aad.tf
@@ -15,8 +15,6 @@ resource "azuread_service_principal_password" "aks_sp_password" {
     ignore_changes = [end_date]
   }
   service_principal_id = azuread_service_principal.aks_sp[0].id
-  value                = var.aks_sp_secret
-  end_date             = timeadd(timestamp(), "43800h") # 5 years
 }
 
 resource "azurerm_role_assignment" "aks_sp_role_assignment" {
@@ -32,6 +30,7 @@ resource "azurerm_role_assignment" "aks_sp_role_assignment" {
 
 # Create a cluster admin group
 resource "azuread_group" "aks-aad-clusteradmins" {
-  count        = var.enable_aad_auth ? 1 : 0
-  display_name = "${var.cluster_name}-clusteradmin"
+  count            = var.enable_aad_auth ? 1 : 0
+  display_name     = "${var.cluster_name}-clusteradmin"
+  security_enabled = true
 }


### PR DESCRIPTION
- fixes the following errors

```
Error: Value for unconfigurable attribute

  on .terraform/modules/working-cluster/aks_cluster/aad.tf line 18, in resource "azuread_service_principal_password" "aks_sp_password":
  18:   value                = var.aks_sp_secret

Can't configure a value for "value": its value will be decided automatically
based on the result of applying this configuration.


Error: Value for unconfigurable attribute

  on .terraform/modules/working-cluster/aks_cluster/aad.tf line 19, in resource "azuread_service_principal_password" "aks_sp_password":
  19:   end_date             = timeadd(timestamp(), "43800h") # 5 years

Can't configure a value for "end_date": its value will be decided
automatically based on the result of applying this configuration.


Error: Missing required argument

  on .terraform/modules/working-cluster/aks_cluster/aad.tf line 34, in resource "azuread_group" "aks-aad-clusteradmins":
  34: resource "azuread_group" "aks-aad-clusteradmins" {

"security_enabled": one of `mail_enabled,security_enabled` must be specified


Error: Missing required argument

  on .terraform/modules/working-cluster/aks_cluster/aad.tf line 34, in resource "azuread_group" "aks-aad-clusteradmins":
  34: resource "azuread_group" "aks-aad-clusteradmins" {

"mail_enabled": one of `mail_enabled,security_enabled` must be specified
```