### PR TITLE
Specify empty string security group for subnets

### DIFF
--- a/virtual_network/CHANGELOG.md
+++ b/virtual_network/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## virtual_network-v0.9.1
+### Added
+`security_group` variable for use in subnet definition
+
 ## virtual_network-v0.8.0
 ### Added
 

--- a/virtual_network/README.md
+++ b/virtual_network/README.md
@@ -64,6 +64,7 @@ The following table lists the configurable parameters that this module accepts.
 | `network_cidr_prefix`         | The network cidr ip prefix                               | `"10.0.0.0"`   |
 | `network_cidr_suffix`         | The network cidr suffix                                  | `8`            |
 | `networks`                    | A list of objects that contain subnets and desired size  | `[{`<br>`name = "subnet-1"`<br>`cidr_block = 18`<br>`},`<br>`{`<br>`name = "subnet-2"`<br>`cidr_block = 18`<br>`}]` |
+| `security_group` | Security group to attach to subnet | "" | |
 | `resource_group_name`         | The resource group to place the Azure network            | `None`         |
 | `additional_tags`             | A map of tags to be appended to Azure objects            | `{}`           |
 

--- a/virtual_network/main.tf
+++ b/virtual_network/main.tf
@@ -25,7 +25,7 @@ resource "azurerm_virtual_network" "network" {
     content {
       name           = subnet.key
       address_prefix = subnet.value
-      security_group = ""
+      security_group = var.security_group
     }
   }
 

--- a/virtual_network/main.tf
+++ b/virtual_network/main.tf
@@ -25,6 +25,7 @@ resource "azurerm_virtual_network" "network" {
     content {
       name           = subnet.key
       address_prefix = subnet.value
+      security_group = ""
     }
   }
 
@@ -32,7 +33,7 @@ resource "azurerm_virtual_network" "network" {
     for_each = var.enable_ddos_protection_plan ? [1] : []
     content {
       enable = var.enable_ddos_protection_plan
-      id = var.ddos_protection_plan_id
+      id     = var.ddos_protection_plan_id
     }
   }
 

--- a/virtual_network/variables.tf
+++ b/virtual_network/variables.tf
@@ -11,6 +11,12 @@ variable "network_cidr_suffix" {
   type        = number
   default     = 8
   description = "The cidr block size for the network"
+
+  variable "security_group" {
+    type        = string
+    default     = ""
+    description = "Network security group associated with the subnet"
+  }
 }
 
 variable "subnets" {
@@ -45,10 +51,10 @@ variable "additional_tags" {
 
 variable "enable_ddos_protection_plan" {
   default = false
-  type = bool
+  type    = bool
 }
 
 variable "ddos_protection_plan_id" {
   default = null
-  type = string
+  type    = string
 }


### PR DESCRIPTION
`terraform apply` on a `azurevm_virtual_network` resource with embedded subnets attempted to destroy and recreate the subnet because the lack of the `security_group` key meant it tried to set it to `null`, but older terraform had set it to an empty string. So, by adding `security_group = ""` it prevents a `terraform plan` from trying to delete the subnet. 